### PR TITLE
Fix LAPACK_DIR in installed lapacke-config.cmake

### DIFF
--- a/LAPACKE/cmake/lapacke-config-install.cmake.in
+++ b/LAPACKE/cmake/lapacke-config-install.cmake.in
@@ -5,7 +5,7 @@ get_filename_component(_LAPACKE_PREFIX "${_LAPACKE_PREFIX}" PATH)
 get_filename_component(_LAPACKE_PREFIX "${_LAPACKE_PREFIX}" PATH)
 
 # Load the LAPACK package with which we were built.
-set(LAPACK_DIR "${_LAPACKE_PREFIX}/@CMAKE_INSTALL_LIBDIR@/cmake/@LAPACK@-@LAPACK_VERSION@")
+set(LAPACK_DIR "${_LAPACKE_PREFIX}/@CMAKE_INSTALL_LIBDIR@/cmake/@LAPACKLIB@-@LAPACK_VERSION@")
 find_package(LAPACK NO_MODULE)
 
 # Load lapacke targets from the install tree.


### PR DESCRIPTION

**Description**

Fixes #550: on fresh install with version 3.9.1, the line in lapacke-config.cmake is:

set(LAPACK_DIR "${_LAPACKE_PREFIX}/lib/cmake/-3.9.1")

And it should be:

set(LAPACK_DIR "${_LAPACKE_PREFIX}/lib/cmake/lapack-3.9.1")


**Checklist**

- [ ] The documententation has been updated
- [ ] If the PR solves a specific issue, it is set to be closed on merge.